### PR TITLE
SEPP-31 Add condition to upload badge on successful merge request

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -151,7 +151,7 @@ jobs:
   # Push badges to badge repo (on successful merge to main)
   push_badges:
     runs-on: ubuntu-latest
-    needs: [upload_badges]
+    needs: [create_badge_artifacts]
     # if: ${{ github.event_name == 'push' }}
     if: github.event.pull_request.merged == true
     steps:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,5 +1,14 @@
 name: CI-CD workflow
-on: [push]
+# on: [push]
+on:
+  push:
+
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -83,7 +92,7 @@ jobs:
             ./build/reports/
           retention-days: 5
 
-  update_badges:
+  create_badge_artifacts:
     runs-on: ubuntu-latest
     needs: [lint_report]
     steps:
@@ -138,6 +147,21 @@ jobs:
             ./stub_artifact.txt
             ./build/badges/
           retention-days: 90
+
+  # Push badges to badge repo (on successful merge to main)
+  push_badges:
+    runs-on: ubuntu-latest
+    needs: [upload_badges]
+    # if: ${{ github.event_name == 'push' }}
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Download badge artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: repo-badge-directory
 
       # Push badge to another repo
       - name: Pushes badge file


### PR DESCRIPTION
The badges should reflect state on master branch, not WIP feature branches